### PR TITLE
[server] make featureVector and userDocuments separate entities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 - conda install --yes python=$TRAVIS_PYTHON_VERSION cryptography numpy scipy
 - pip install -r requirements.txt
 - pip install -r test_requirements.txt
-- pip install -e src/scraper src/server src/common src/topicmodeller src/learner src/orchestrator
+- pip install -e src/common -e src/scraper -e src/server -e src/topicmodeller -e src/learner -e src/orchestrator
 - pip install coveralls
 - python -m nltk.downloader stopwords
 - python -m nltk.downloader punkt

--- a/pylintrc
+++ b/pylintrc
@@ -7,8 +7,6 @@
 # pygtk.require().
 init-hook='sys.path = sys.path + ["lib/google_appengine/lib/webapp2-2.5.2", "lib/google_appengine/lib/jinja2-2.6", "lib/google_appengine", "tools"]'
 
-# Profiled execution.
-profile=no
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
@@ -96,9 +94,6 @@ reports=yes
 # (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (RP0004).
-comment=no
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
@@ -107,8 +102,6 @@ comment=no
 
 [BASIC]
 
-# Required attributes for module, separated by a comma
-required-attributes=
 
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,filter,input
@@ -228,10 +221,6 @@ ignored-modules=
 # (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject
 
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
-
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
 # expressions are accepted.
@@ -332,10 +321,6 @@ int-import-graph=
 
 
 [CLASSES]
-
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp

--- a/pylintrc_tests
+++ b/pylintrc_tests
@@ -7,8 +7,6 @@
 # pygtk.require().
 init-hook='sys.path = sys.path + ["lib/google_appengine/lib/webapp2-2.5.2", "lib/google_appengine/lib/jinja2-2.6", "lib/google_appengine", "tools"]'
 
-# Profiled execution.
-profile=no
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
@@ -97,9 +95,6 @@ reports=yes
 # (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (RP0004).
-comment=no
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
@@ -108,8 +103,6 @@ comment=no
 
 [BASIC]
 
-# Required attributes for module, separated by a comma
-required-attributes=
 
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,filter,input
@@ -230,10 +223,6 @@ ignored-modules=
 # (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject
 
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
-
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
 # expressions are accepted.
@@ -334,10 +323,6 @@ int-import-graph=
 
 
 [CLASSES]
-
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp

--- a/src/common/common/topicmodellerstructs.py
+++ b/src/common/common/topicmodellerstructs.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+
 class TopicModellerDocument(object):
     def __init__(self, title, url, topics):
         self.title = title
         self.url = url
-        self.topics = topics
+        # TODO I think we should replace it by two vectors to operate without deconstructing each tuple pylint: disable=fixme
+        self.topics = topics # topics is a list of tuples (topic_label_string, topic_value_double)
+

--- a/src/learner/learner/learner.py
+++ b/src/learner/learner/learner.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from server.frontendstructs import UserDocument
+
+class UserDocMatching(object):
+    def __init__(self, is_doc_relevant, grade):
+        self.is_doc_relevant = is_doc_relevant
+        self.grade = grade
 
 
-def learn_for_users(users, document, topics, min_grade):
-    weights = [weight for (_, weight) in topics]
-    for user in users:
-        grade = sum(a * b for (a, b) in
-                    zip(weights, user.feature_vector.vector))
-        if grade > min_grade:
-            user.user_docs.append(UserDocument(document, grade))
+def compute_user_doc_matching(user_feature_vectors, document_feature_vector, min_grade):
+    users_doc_matching = []
+    for user_feature_vector in user_feature_vectors:
+        grade = sum(a * b for (a, b) in zip(user_feature_vector, document_feature_vector))
+        users_doc_matching.append(UserDocMatching(is_doc_relevant=grade > min_grade, grade=grade))
+    return users_doc_matching

--- a/src/learner/learner/learner.py
+++ b/src/learner/learner/learner.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from scipy.spatial import distance
+import numpy as np
 
 
 class UserDocMatching(object):
@@ -9,8 +11,16 @@ class UserDocMatching(object):
 
 
 def compute_user_doc_matching(user_feature_vectors, document_feature_vector, min_grade):
-    users_doc_matching = []
-    for user_feature_vector in user_feature_vectors:
-        grade = sum(a * b for (a, b) in zip(user_feature_vector, document_feature_vector))
-        users_doc_matching.append(UserDocMatching(is_doc_relevant=grade > min_grade, grade=grade))
-    return users_doc_matching
+    grade_vec = similarity_by_row(user_feature_vectors, document_feature_vector)
+    return [UserDocMatching(is_doc_relevant=grade > min_grade, grade=grade) for grade in np.nditer(grade_vec)]
+
+
+def similarity_by_row(matrix, vector):
+    """
+    compute the cosine similarity (normalized dot product) for each row of 'matrix' against 'vector'
+    :param matrix: array of array or numpy matrix of dimension (n elements, p features)
+    :param vector: vector of dimension p features
+    :return: vector of size n
+    """
+    vec_as_1_p_matrix = [vector]
+    return 1 - distance.cdist(matrix, vec_as_1_p_matrix, metric='cosine')

--- a/src/learner/tests/test_learner.py
+++ b/src/learner/tests/test_learner.py
@@ -3,76 +3,26 @@
 
 import unittest
 
-from learner.learner import learn_for_users
-from server.frontendstructs import Document, FeatureVector, User
+from learner.learner import compute_user_doc_matching
 
 
 class LearnerTests(unittest.TestCase):
-    @classmethod
-    def create_user(cls, feature_vector):
-        feature_vector = FeatureVector(vector=feature_vector, labels=[], feature_set_id=None)
-        user = User(u'', [], feature_vector)
-        return user
 
-    @classmethod
-    def create_document(cls):
-        return Document.make_from_scratch(url=u'', title=u'', summary=None)
+    def test_compute_user_doc_matching_with_grade_above_should_flag_doc_as_relevant(self):
 
-    def create_users_documents_and_learn(self, users_feature_vector, min_grade, documents_topics):
-        users = [self.create_user(feature_vector) for feature_vector in users_feature_vector]
+        user1_feature_vector = [0.49, 1.0, 0.0]
+        user2_feature_vector = [0.5, 1.0, 0.1]
 
-        document_and_topics = [(self.create_document(), topics) for topics in documents_topics]
+        user_feature_vectors = [user1_feature_vector, user2_feature_vector]
 
-        for (document, topics) in document_and_topics:
-            learn_for_users(users=users, document=document, topics=topics, min_grade=min_grade)
+        matching = compute_user_doc_matching(
+            user_feature_vectors=user_feature_vectors, document_feature_vector=[1.0, 0.5, 0.1], min_grade=1.0)
 
-        return (users, [document for (document, topics) in document_and_topics])
+        self.assertFalse(matching[0].is_doc_relevant)
+        self.assertEqual(0.99, matching[0].grade)
+        self.assertTrue(matching[1].is_doc_relevant)
+        self.assertEqual(1.01, matching[1].grade)
 
-    def test_associate_document(self):
-        (users, documents) = self.create_users_documents_and_learn(
-            users_feature_vector=[[0, 1, 0, 0]],
-            min_grade=0.5,
-            documents_topics=[[(1, 0), (2, 0.6), (3, 0), (4, 0)]])
-
-        self.assertIn(documents[0], [user_doc.document for user_doc in users[0].user_docs])
-
-    def test_associate_each_document_to_one_user(self):
-        (users, documents) = self.create_users_documents_and_learn(
-            users_feature_vector=[[0, 1, 0, 0.05], [0, 0.1, 0, 0.8]],
-            min_grade=0.5,
-            documents_topics=[[(1, 0), (2, 0.6), (3, 0), (4, 0)], [(1, 0), (2, 0), (3, 0), (4, 0.7)]])
-
-        for (user, document) in zip(users, documents):
-            self.assertIn(document, [user_doc.document for user_doc in user.user_docs])
-
-        users.reverse()
-        for (user, document) in zip(users, documents):
-            self.assertNotIn(document, [user_doc.document for user_doc in user.user_docs])
-
-    def test_associate_document_to_multiple_users(self):
-        (users, documents) = self.create_users_documents_and_learn(
-            users_feature_vector=[[0, 0.9, 0, 0.05], [0, 0.2, 0, 0.4]],
-            min_grade=0.49,
-            documents_topics=[[(1, 0), (2, 0.5), (3, 0), (4, 1)]])
-
-        for user in users:
-            self.assertIn(documents[0], [user_doc.document for user_doc in user.user_docs])
-
-    def test_do_not_associate_document_min_grade_high(self):
-        (users, documents) = self.create_users_documents_and_learn(
-            users_feature_vector=[[0, 1, 0, 0]],
-            min_grade=1,
-            documents_topics=[[(1, 0), (2, 0.6), (3, 0), (4, 0)]])
-
-        self.assertNotIn(documents[0], [user_doc.document for user_doc in users[0].user_docs])
-
-    def test_do_not_associate_document_grade_inf_min_grade(self):
-        (users, documents) = self.create_users_documents_and_learn(
-            users_feature_vector=[[1, 1, 0, 0]],
-            min_grade=0.5,
-            documents_topics=[[(1, 0.1), (2, 0.3), (3, 0), (4, 0)]])
-
-        self.assertNotIn(documents[0], [user_doc.document for user_doc in users[0].user_docs])
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/learner/tests/test_learner.py
+++ b/src/learner/tests/test_learner.py
@@ -16,7 +16,7 @@ class LearnerTests(unittest.TestCase):
 
     @classmethod
     def create_document(cls):
-        return Document(url=u'', title=u'', db_key=0)
+        return Document.make_from_scratch(url=u'', title=u'', summary=None)
 
     def create_users_documents_and_learn(self, users_feature_vector, min_grade, documents_topics):
         users = [self.create_user(feature_vector) for feature_vector in users_feature_vector]

--- a/src/learner/tests/test_learner.py
+++ b/src/learner/tests/test_learner.py
@@ -1,27 +1,29 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+from math import sqrt
 import unittest
-
 from learner.learner import compute_user_doc_matching
+
+
+# test implementation of L2 norm without re-using numpy code
+def norm(vec):
+    return sqrt(sum(x*x for x in vec))
 
 
 class LearnerTests(unittest.TestCase):
 
     def test_compute_user_doc_matching_with_grade_above_should_flag_doc_as_relevant(self):
+        user1 = [0.49, 1.0, 0.0]
+        user2 = [0.5, 1.0, 0.1]
+        users = [user1, user2]
+        doc = [1.0, 0.5, 0.1]
 
-        user1_feature_vector = [0.49, 1.0, 0.0]
-        user2_feature_vector = [0.5, 1.0, 0.1]
-
-        user_feature_vectors = [user1_feature_vector, user2_feature_vector]
-
-        matching = compute_user_doc_matching(
-            user_feature_vectors=user_feature_vectors, document_feature_vector=[1.0, 0.5, 0.1], min_grade=1.0)
+        matching = compute_user_doc_matching(user_feature_vectors=users, document_feature_vector=doc, min_grade=0.8)
 
         self.assertFalse(matching[0].is_doc_relevant)
-        self.assertEqual(0.99, matching[0].grade)
+        self.assertEqual(0.99/(norm(user1)*norm(doc)), matching[0].grade)
         self.assertTrue(matching[1].is_doc_relevant)
-        self.assertEqual(1.01, matching[1].grade)
+        self.assertEqual(1.01/(norm(user2)*norm(doc)), matching[1].grade)
 
 
 if __name__ == '__main__':

--- a/src/orchestrator/tests/test_orchestrator.py
+++ b/src/orchestrator/tests/test_orchestrator.py
@@ -10,6 +10,7 @@ from orchestrator.orchestrator import _to_json, _setup_env
 from common.scraperstructs import Document, LinkElement
 from scraper.scraper import _get_doc_generator
 
+
 class OrchestratorTests(unittest.TestCase):
 
     def test_get_json_doc_generator(self):

--- a/src/poc/pipeline.py
+++ b/src/poc/pipeline.py
@@ -1,0 +1,1 @@
+__author__ = 'nico'

--- a/src/server/server/dal.py
+++ b/src/server/server/dal.py
@@ -3,32 +3,49 @@ DAL (Data Access Layer) module
 abstract database scheme and ndb API to communicate with the rest of the package through pure (not ndb) Python objects
 """
 from google.appengine.ext import ndb
-import dbentities as db # pylint: disable=relative-import
-from frontendstructs import Document, UserDocument, User, FeatureVector # pylint: disable=relative-import
+import dbentities as db  # pylint: disable=relative-import
+import frontendstructs as struct  # pylint: disable=relative-import
+
 # problem (to solve) with app engine: server is not seen as a package by GAE
 # so you can't do proper relative import (from . import dbentities) as expected by pylint / pep8
 
 
 def get_user(email):
     db_user = db.User.get(email)
-    if db_user is None:
-        return None
+    return _to_user(db_user) if db_user else None
 
-    user_docs = _to_user_docs(db_user.user_documents)
-    feature_vector = _to_feature_vector(db_user.feature_vector)
 
-    return User(email=email, user_docs=user_docs, feature_vector=feature_vector)
+def _to_user(db_user):
+    return struct.User.make_from_db(
+        email=db_user.key.id(),
+        user_doc_set_db_key=db_user.user_document_set_key,
+        feature_vector_db_key=db_user.feature_vector_key)
+
+
+def get_all_users():
+    all_users_query = db.User.query()
+    return [_to_user(db_user) for db_user in all_users_query.iter()]
 
 
 def save_user(user):
-    db_user_docs = _to_db_user_docs(user.user_docs)
-    db_feature_vector = _to_db_feature_vector(user.feature_vector)
+    """
+    save a user into the database, if it's newly created, db_keys will be initialized
+    """
+    if user.user_doc_set_db_key is None:
+        user.user_doc_set_db_key = db.UserDocumentSet.make().put()
+    if user.feature_vector_db_key is None:
+        user.feature_vector_db_key = db.FeatureVector.make(NULL_FEATURE_SET, []).put()
 
+    db_user = _to_db_user(user)
+    db_user.put()
+
+
+def _to_db_user(user):
     db_user = db.User.make(user_id=user.email,
                            google_user_id=None,
-                           user_documents=db_user_docs,
-                           feature_vector=db_feature_vector)
-    db_user.put()
+                           user_document_set_key=user.user_doc_set_db_key,
+                           feature_vector_key=user.feature_vector_db_key)
+    return db_user
 
 
 def get_features(feature_set_id):
@@ -36,44 +53,73 @@ def get_features(feature_set_id):
     return [feature.name for feature in db_feature_set.features]
 
 
-def _to_feature_vector(db_feature_vector):
-    if db_feature_vector is None:
-        return None
+def save_user_feature_vector(user, feature_vector):
+    db_feature_vector = _to_db_feature_vector(feature_vector)
+    db_feature_vector.key = user.feature_vector_db_key
+    db_feature_vector.put()
 
+
+def get_user_feature_vector(user):
+    return _to_feature_vector(user.feature_vector_db_key.get())
+
+
+def _to_feature_vector(db_feature_vector):
     vector = db_feature_vector.vector
     feature_set_db_key = db_feature_vector.feature_set_key
-    labels = [feature.name for feature in feature_set_db_key.get().features]
-    return FeatureVector(vector=vector, labels=labels, feature_set_id=feature_set_db_key.id())
-
-
-def _to_user_docs(db_user_docs):
-    db_doc_keys = [user_doc.document_key for user_doc in db_user_docs]
-    db_docs = ndb.get_multi(db_doc_keys)
-    docs = (Document(url=db_doc.url, title=db_doc.title, db_key=db_doc.key) for db_doc in db_docs)
-    user_docs = [UserDocument(document=doc, grade=user_doc.grade) for doc, user_doc in zip(docs, db_user_docs)]
-    return user_docs
-
-
-def _to_db_user_docs(user_docs):
-    return [db.UserDocument.make(document_key=user_doc.document.db_key, grade=user_doc.grade) for user_doc in user_docs]
+    feature_set = feature_set_db_key.get()
+    labels = [feature.name for feature in feature_set.features]
+    return struct.FeatureVector(vector=vector, labels=labels, feature_set_id=feature_set_db_key.id())
 
 
 def _to_db_feature_vector(feature_vector):
     return db.FeatureVector.make(feature_vector.feature_set_id, vector=feature_vector.vector)
 
 
+def _to_user_docs(db_user_docs):
+    db_doc_keys = [user_doc.document_key for user_doc in db_user_docs]
+    db_docs = ndb.get_multi(db_doc_keys)
+    docs = (struct.Document.make_from_db(
+        url=db_doc.url, title=db_doc.title, summary=db_doc.summary, date=db_doc.date, db_key=db_doc.key)
+            for db_doc in db_docs)
+    user_docs = [struct.UserDocument(document=doc, grade=user_doc.grade) for doc, user_doc in zip(docs, db_user_docs)]
+    return user_docs
+
+
+def save_user_docs(user, user_docs):
+    db_user_docs = [
+        db.UserDocument.make(document_key=user_doc.document.db_key, grade=user_doc.grade) for user_doc in user_docs]
+    user_doc_set = user.user_doc_set_db_key.get()
+    user_doc_set.user_documents = db_user_docs
+    user_doc_set.put()
+
+
+def get_user_docs(user):
+    user_doc_set = user.user_doc_set_db_key.get()
+    return _to_user_docs(user_doc_set.user_documents)
+
+
+def save_documents(documents):
+    docs_with_order = [doc for doc in documents]
+    db_docs = [db.Document.make(url=doc.url, title=doc.title, summary=doc.summary) for doc in docs_with_order]
+    db_doc_keys = ndb.put_multi(db_docs)
+    for (doc, key) in zip(documents, db_doc_keys):
+        doc.db_key = key
+
+
 # should be deleted, just to mock input from scraper/learner
 def init_user_dummy(user_id):
-    dummy_doc1 = db.Document.make(url='https://www.google.com', title='google.com', summary='we will buy you')
-    dummy_doc2 = db.Document.make(url='gator.life', title='gator.life', summary='YGNI')
-    ndb.put_multi([dummy_doc1, dummy_doc2])  # we must store docs before creating user to init key field
-    new_user = db.User.make(user_id=user_id,
-                            google_user_id=None,
-                            user_documents=[db.UserDocument.make(document_key=dummy_doc1.key, grade=1.0),
-                                            db.UserDocument.make(document_key=dummy_doc2.key, grade=0.5)],
-                            feature_vector=None)
+    dummy_doc1 = struct.Document.make_from_scratch(
+        url='https://www.google.com', title='google.com', summary='we will buy you')
+    dummy_doc2 = struct.Document.make_from_scratch(
+        url='gator.life', title='gator.life', summary='YGNI')
+    save_documents([dummy_doc1, dummy_doc2])
 
-    new_user.put()
+    new_user = struct.User.make_from_scratch(email=user_id)
+    save_user(new_user)
+    user_doc1 = struct.UserDocument(document=dummy_doc1, grade=1.0)
+    user_doc2 = struct.UserDocument(document=dummy_doc2, grade=0.5)
+    save_user_docs(new_user, [user_doc1, user_doc2])
+    return new_user
 
 
 # should be deleted, just to mock input from scraper/learner
@@ -84,6 +130,9 @@ def init_features_dummy(feature_set_id):
     feature_set.put()
 
 
-NEW_USER_ID = "new_user_id"
+def init_null_feature_set():
+    db.FeatureSet.make(NULL_FEATURE_SET, []).put()
 
+NEW_USER_ID = "new_user_id"
 REF_FEATURE_SET = "ref_feature_set"
+NULL_FEATURE_SET = "null_feature_set"

--- a/src/server/server/dal.py
+++ b/src/server/server/dal.py
@@ -31,10 +31,10 @@ def save_user(user):
     """
     save a user into the database, if it's newly created, db_keys will be initialized
     """
-    if user.user_doc_set_db_key is None:
-        user.user_doc_set_db_key = db.UserDocumentSet.make().put()
-    if user.feature_vector_db_key is None:
-        user.feature_vector_db_key = db.FeatureVector.make(NULL_FEATURE_SET, []).put()
+    if user._user_doc_set_db_key is None:  # pylint: disable=protected-access
+        user._user_doc_set_db_key = db.UserDocumentSet.make().put()  # pylint: disable=protected-access
+    if user._feature_vector_db_key is None:  # pylint: disable=protected-access
+        user._feature_vector_db_key = db.FeatureVector.make(NULL_FEATURE_SET, []).put()  # pylint: disable=protected-access
 
     db_user = _to_db_user(user)
     db_user.put()
@@ -43,8 +43,8 @@ def save_user(user):
 def _to_db_user(user):
     db_user = db.User.make(user_id=user.email,
                            google_user_id=None,
-                           user_document_set_key=user.user_doc_set_db_key,
-                           feature_vector_key=user.feature_vector_db_key)
+                           user_document_set_key=user._user_doc_set_db_key,  # pylint: disable=protected-access
+                           feature_vector_key=user._feature_vector_db_key)  # pylint: disable=protected-access
     return db_user
 
 
@@ -55,12 +55,12 @@ def get_features(feature_set_id):
 
 def save_user_feature_vector(user, feature_vector):
     db_feature_vector = _to_db_feature_vector(feature_vector)
-    db_feature_vector.key = user.feature_vector_db_key
+    db_feature_vector.key = user._feature_vector_db_key  # pylint: disable=protected-access
     db_feature_vector.put()
 
 
 def get_user_feature_vector(user):
-    return _to_feature_vector(user.feature_vector_db_key.get())
+    return _to_feature_vector(user._feature_vector_db_key.get())  # pylint: disable=protected-access
 
 
 def _to_feature_vector(db_feature_vector):
@@ -88,14 +88,17 @@ def _to_user_docs(db_user_docs):
 
 def save_user_docs(user, user_docs):
     db_user_docs = [
-        db.UserDocument.make(document_key=user_doc.document.db_key, grade=user_doc.grade) for user_doc in user_docs]
-    user_doc_set = user.user_doc_set_db_key.get()
+        db.UserDocument.make(
+            document_key=user_doc.document._db_key,  # pylint: disable=protected-access
+            grade=user_doc.grade
+        ) for user_doc in user_docs]
+    user_doc_set = user._user_doc_set_db_key.get()  # pylint: disable=protected-access
     user_doc_set.user_documents = db_user_docs
     user_doc_set.put()
 
 
 def get_user_docs(user):
-    user_doc_set = user.user_doc_set_db_key.get()
+    user_doc_set = user._user_doc_set_db_key.get()  # pylint: disable=protected-access
     return _to_user_docs(user_doc_set.user_documents)
 
 
@@ -104,7 +107,7 @@ def save_documents(documents):
     db_docs = [db.Document.make(url=doc.url, title=doc.title, summary=doc.summary) for doc in docs_with_order]
     db_doc_keys = ndb.put_multi(db_docs)
     for (doc, key) in zip(documents, db_doc_keys):
-        doc.db_key = key
+        doc._db_key = key  # pylint: disable=protected-access
 
 
 # should be deleted, just to mock input from scraper/learner

--- a/src/server/server/dal.py
+++ b/src/server/server/dal.py
@@ -68,7 +68,7 @@ def _to_feature_vector(db_feature_vector):
     feature_set_db_key = db_feature_vector.feature_set_key
     feature_set = feature_set_db_key.get()
     labels = [feature.name for feature in feature_set.features]
-    return struct.FeatureVector(vector=vector, labels=labels, feature_set_id=feature_set_db_key.id())
+    return struct.FeatureVector.make_from_scratch(vector=vector, labels=labels, feature_set_id=feature_set_db_key.id())
 
 
 def _to_db_feature_vector(feature_vector):
@@ -81,7 +81,8 @@ def _to_user_docs(db_user_docs):
     docs = (struct.Document.make_from_db(
         url=db_doc.url, title=db_doc.title, summary=db_doc.summary, date=db_doc.date, db_key=db_doc.key)
             for db_doc in db_docs)
-    user_docs = [struct.UserDocument(document=doc, grade=user_doc.grade) for doc, user_doc in zip(docs, db_user_docs)]
+    user_docs = [struct.UserDocument.make_from_scratch(
+        document=doc, grade=user_doc.grade) for doc, user_doc in zip(docs, db_user_docs)]
     return user_docs
 
 
@@ -116,8 +117,8 @@ def init_user_dummy(user_id):
 
     new_user = struct.User.make_from_scratch(email=user_id)
     save_user(new_user)
-    user_doc1 = struct.UserDocument(document=dummy_doc1, grade=1.0)
-    user_doc2 = struct.UserDocument(document=dummy_doc2, grade=0.5)
+    user_doc1 = struct.UserDocument.make_from_scratch(document=dummy_doc1, grade=1.0)
+    user_doc2 = struct.UserDocument.make_from_scratch(document=dummy_doc2, grade=0.5)
     save_user_docs(new_user, [user_doc1, user_doc2])
     return new_user
 

--- a/src/server/server/dal.py
+++ b/src/server/server/dal.py
@@ -63,12 +63,15 @@ def get_user_feature_vector(user):
     return _to_feature_vector(user._feature_vector_db_key.get())  # pylint: disable=protected-access
 
 
+def get_users_feature_vectors(users):
+    db_feature_vectors = ndb.get_multi(user._feature_vector_db_key for user in users)  # pylint: disable=protected-access
+    return [_to_feature_vector(db_vec) for db_vec in db_feature_vectors]
+
+
 def _to_feature_vector(db_feature_vector):
     vector = db_feature_vector.vector
-    feature_set_db_key = db_feature_vector.feature_set_key
-    feature_set = feature_set_db_key.get()
-    labels = [feature.name for feature in feature_set.features]
-    return struct.FeatureVector.make_from_scratch(vector=vector, labels=labels, feature_set_id=feature_set_db_key.id())
+    feature_set_id = db_feature_vector.feature_set_key.id()
+    return struct.FeatureVector.make_from_scratch(vector=vector, feature_set_id=feature_set_id)
 
 
 def _to_db_feature_vector(feature_vector):

--- a/src/server/server/dbentities.py
+++ b/src/server/server/dbentities.py
@@ -25,6 +25,17 @@ class UserDocument(ndb.Model):
         return UserDocument(document_key=document_key, grade=grade)
 
 
+class UserDocumentSet(ndb.Model):
+    user_documents = ndb.StructuredProperty(UserDocument, indexed=False, repeated=True)
+
+    @staticmethod
+    def make():
+        return UserDocumentSet(user_documents=[])
+
+    def set_user_documents(self, user_documents):
+        self.user_documents = user_documents
+
+
 class FeatureDescription(ndb.Model):
     name = ndb.StringProperty(indexed=False, required=True)
 
@@ -56,12 +67,16 @@ class FeatureVector(ndb.Model):
 
 class User(ndb.Model):
     google_user_id = ndb.StringProperty(indexed=True, required=False)
-    user_documents = ndb.StructuredProperty(UserDocument, repeated=True)
-    feature_vector = ndb.StructuredProperty(FeatureVector, repeated=False, required=False)
+    user_document_set_key = ndb.KeyProperty(UserDocumentSet, indexed=False, required=True)
+    feature_vector_key = ndb.KeyProperty(FeatureVector, repeated=False, required=True)
 
     @staticmethod
-    def make(user_id, google_user_id, user_documents, feature_vector):
-        return User(id=user_id, google_user_id=google_user_id, user_documents=user_documents, feature_vector=feature_vector)
+    def make(user_id, google_user_id, user_document_set_key, feature_vector_key):
+        return User(
+            id=user_id,
+            google_user_id=google_user_id,
+            user_document_set_key=user_document_set_key,
+            feature_vector_key=feature_vector_key)
 
     @staticmethod
     def get(user_id):

--- a/src/server/server/dbentities.py
+++ b/src/server/server/dbentities.py
@@ -5,6 +5,9 @@ this module should not be included except from dal.py
 from google.appengine.ext import ndb
 
 
+
+# ----------- entities modified by backend -----------
+
 class Document(ndb.Model):
     url = ndb.StringProperty(indexed=False, required=True)  # NB: url cannot be the key because it's 500 bytes max
     title = ndb.StringProperty(indexed=False, required=True)
@@ -64,6 +67,8 @@ class FeatureVector(ndb.Model):
     def make(feature_set_id, vector):
         return FeatureVector(feature_set_key=ndb.Key(FeatureSet, feature_set_id), vector=vector)
 
+
+# ----------- entities modified by frontend -----------
 
 class User(ndb.Model):
     google_user_id = ndb.StringProperty(indexed=True, required=False)

--- a/src/server/server/frontendstructs.py
+++ b/src/server/server/frontendstructs.py
@@ -15,7 +15,7 @@ class Document(object):
     def __init__(self, url, title, summary, date, db_key):
         self.url = url
         self.title = title
-        self.db_key = db_key
+        self._db_key = db_key
         self.summary = summary
         self.date = date
 
@@ -43,8 +43,8 @@ class User(object):
 
     def __init__(self, email, user_doc_set_db_key, feature_vector_db_key):
         self.email = email
-        self.user_doc_set_db_key = user_doc_set_db_key
-        self.feature_vector_db_key = feature_vector_db_key
+        self._user_doc_set_db_key = user_doc_set_db_key
+        self._feature_vector_db_key = feature_vector_db_key
 
 
 class FeatureVector(object):

--- a/src/server/server/frontendstructs.py
+++ b/src/server/server/frontendstructs.py
@@ -21,6 +21,11 @@ class Document(object):
 
 
 class UserDocument(object):
+
+    @staticmethod
+    def make_from_scratch(document, grade):
+        return UserDocument(document, grade)
+
     def __init__(self, document, grade):
         self.document = document
         self.grade = grade
@@ -43,6 +48,11 @@ class User(object):
 
 
 class FeatureVector(object):
+
+    @staticmethod
+    def make_from_scratch(vector, labels, feature_set_id):
+        return FeatureVector(vector, labels, feature_set_id)
+
     def __init__(self, vector, labels, feature_set_id):
         self.vector = vector
         self.labels = labels

--- a/src/server/server/frontendstructs.py
+++ b/src/server/server/frontendstructs.py
@@ -1,11 +1,23 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+
 class Document(object):
-    def __init__(self, url, title, db_key):
+
+    @staticmethod
+    def make_from_db(url, title, summary, date, db_key):
+        return Document(url, title, summary, date, db_key)
+
+    @staticmethod
+    def make_from_scratch(url, title, summary):
+        return Document(url, title, summary, date=None, db_key=None)
+
+    def __init__(self, url, title, summary, date, db_key):
         self.url = url
         self.title = title
         self.db_key = db_key
+        self.summary = summary
+        self.date = date
 
 
 class UserDocument(object):
@@ -15,10 +27,19 @@ class UserDocument(object):
 
 
 class User(object):
-    def __init__(self, email, user_docs, feature_vector):
+
+    @staticmethod
+    def make_from_db(email, user_doc_set_db_key, feature_vector_db_key):
+        return User(email, user_doc_set_db_key, feature_vector_db_key)
+
+    @staticmethod
+    def make_from_scratch(email):
+        return User(email, None, None)
+
+    def __init__(self, email, user_doc_set_db_key, feature_vector_db_key):
         self.email = email
-        self.user_docs = user_docs
-        self.feature_vector = feature_vector
+        self.user_doc_set_db_key = user_doc_set_db_key
+        self.feature_vector_db_key = feature_vector_db_key
 
 
 class FeatureVector(object):

--- a/src/server/server/frontendstructs.py
+++ b/src/server/server/frontendstructs.py
@@ -50,10 +50,9 @@ class User(object):
 class FeatureVector(object):
 
     @staticmethod
-    def make_from_scratch(vector, labels, feature_set_id):
-        return FeatureVector(vector, labels, feature_set_id)
+    def make_from_scratch(vector, feature_set_id):
+        return FeatureVector(vector, feature_set_id)
 
-    def __init__(self, vector, labels, feature_set_id):
+    def __init__(self, vector, feature_set_id):
         self.vector = vector
-        self.labels = labels
         self.feature_set_id = feature_set_id

--- a/src/server/server/gator.py
+++ b/src/server/server/gator.py
@@ -21,6 +21,7 @@ ROUTING = [
 
 dal.init_user_dummy(dal.NEW_USER_ID)
 dal.init_features_dummy(dal.REF_FEATURE_SET)
+dal.init_null_feature_set()
 
 # 'app' name is the convention for webapp. It must match the suffix of the 'script' directive in app.yaml file
 # cf. https://cloud.google.com/appengine/docs/python/config/appconfig

--- a/src/server/server/handlers.py
+++ b/src/server/server/handlers.py
@@ -38,8 +38,7 @@ class HomePageHandler(webapp2.RequestHandler):
             feature_set_id = self.request.get('feature_set_id')
             labels = dal.get_features(feature_set_id)
             vector = [float(self.request.get(label)) for label in labels]
-            feature_vector = struct.FeatureVector.make_from_scratch(
-                vector=vector, labels=labels, feature_set_id=feature_set_id)
+            feature_vector = struct.FeatureVector.make_from_scratch(vector=vector, feature_set_id=feature_set_id)
             dal.save_user_feature_vector(user, feature_vector)
 
         feature_vector = dal.get_user_feature_vector(user)
@@ -47,17 +46,17 @@ class HomePageHandler(webapp2.RequestHandler):
             feature_set_id = dal.REF_FEATURE_SET
             labels = dal.get_features(dal.REF_FEATURE_SET)
             vector = [x * 0.1 for x in range(len(labels))]
-            feature_vector = struct.FeatureVector.make_from_scratch(
-                labels=labels, vector=vector, feature_set_id=feature_set_id)
+            feature_vector = struct.FeatureVector.make_from_scratch(vector=vector, feature_set_id=feature_set_id)
 
         return feature_vector
 
     def post(self):
         user = self._get_or_create_user()
         feature_vector = self._get_or_create_features(user)
+        labels = dal.get_features(feature_vector.feature_set_id)
         user_docs = dal.get_user_docs(user)
         links = [Link(link=user_doc.document.url, text=user_doc.document.title) for user_doc in user_docs]
-        features = [Feature(label, value) for (label, value) in zip(feature_vector.labels, feature_vector.vector)]
+        features = [Feature(label, value) for (label, value) in zip(labels, feature_vector.vector)]
 
         template_values = {
             'email': user.email,

--- a/src/server/server/handlers.py
+++ b/src/server/server/handlers.py
@@ -38,7 +38,8 @@ class HomePageHandler(webapp2.RequestHandler):
             feature_set_id = self.request.get('feature_set_id')
             labels = dal.get_features(feature_set_id)
             vector = [float(self.request.get(label)) for label in labels]
-            feature_vector = struct.FeatureVector(vector=vector, labels=labels, feature_set_id=feature_set_id)
+            feature_vector = struct.FeatureVector.make_from_scratch(
+                vector=vector, labels=labels, feature_set_id=feature_set_id)
             dal.save_user_feature_vector(user, feature_vector)
 
         feature_vector = dal.get_user_feature_vector(user)
@@ -46,7 +47,8 @@ class HomePageHandler(webapp2.RequestHandler):
             feature_set_id = dal.REF_FEATURE_SET
             labels = dal.get_features(dal.REF_FEATURE_SET)
             vector = [x * 0.1 for x in range(len(labels))]
-            feature_vector = struct.FeatureVector(labels=labels, vector=vector, feature_set_id=feature_set_id)
+            feature_vector = struct.FeatureVector.make_from_scratch(
+                labels=labels, vector=vector, feature_set_id=feature_set_id)
 
         return feature_vector
 

--- a/src/server/server/handlers.py
+++ b/src/server/server/handlers.py
@@ -1,7 +1,7 @@
 import webapp2
-
 import dal  # pylint: disable=relative-import
-import jinjaenvironment # pylint: disable=relative-import
+import jinjaenvironment  # pylint: disable=relative-import
+import frontendstructs as struct  # pylint: disable=relative-import
 
 
 class Link(object):
@@ -28,8 +28,8 @@ class HomePageHandler(webapp2.RequestHandler):
         email = self.request.get('email')
         user = dal.get_user(email)
         if user is None:
-            dal.init_user_dummy(email)
-            user = dal.get_user(email)
+            user = dal.init_user_dummy(email)
+            dal.save_user(user)
         return user
 
     def _get_or_create_features(self, user):
@@ -38,30 +38,30 @@ class HomePageHandler(webapp2.RequestHandler):
             feature_set_id = self.request.get('feature_set_id')
             labels = dal.get_features(feature_set_id)
             vector = [float(self.request.get(label)) for label in labels]
-            user.feature_vector = dal.FeatureVector(vector=vector, labels=labels, feature_set_id=feature_set_id)
-            dal.save_user(user)
+            feature_vector = struct.FeatureVector(vector=vector, labels=labels, feature_set_id=feature_set_id)
+            dal.save_user_feature_vector(user, feature_vector)
 
-        feature_vector = user.feature_vector
-        if feature_vector is None:
+        feature_vector = dal.get_user_feature_vector(user)
+        if feature_vector.feature_set_id == dal.NULL_FEATURE_SET:
             feature_set_id = dal.REF_FEATURE_SET
             labels = dal.get_features(dal.REF_FEATURE_SET)
             vector = [x * 0.1 for x in range(len(labels))]
-            feature_vector = dal.FeatureVector(labels=labels, vector=vector, feature_set_id=feature_set_id)
+            feature_vector = struct.FeatureVector(labels=labels, vector=vector, feature_set_id=feature_set_id)
 
         return feature_vector
 
     def post(self):
         user = self._get_or_create_user()
         feature_vector = self._get_or_create_features(user)
-
-        links = [Link(link=user_doc.document.url, text=user_doc.document.title) for user_doc in user.user_docs]
+        user_docs = dal.get_user_docs(user)
+        links = [Link(link=user_doc.document.url, text=user_doc.document.title) for user_doc in user_docs]
         features = [Feature(label, value) for (label, value) in zip(feature_vector.labels, feature_vector.vector)]
 
         template_values = {
             'email': user.email,
             'links': links,
             'features': features,
-            'feature_set_id':feature_vector.feature_set_id
+            'feature_set_id': feature_vector.feature_set_id
         }
         response = jinjaenvironment.render_template(html_file='index.html', attributes_dict=template_values)
 

--- a/src/server/tests/test_dal.py
+++ b/src/server/tests/test_dal.py
@@ -40,7 +40,7 @@ class DalTests(unittest.TestCase):
         self.assertIsNone(expected_user.feature_vector_db_key)
         self.assertIsNone(expected_user.user_doc_set_db_key)
         dal.save_user(expected_user)
-        #save should init db keys
+        # save should init db keys
         self.assertIsNotNone(expected_user.user_doc_set_db_key)
         self.assertIsNotNone(expected_user.feature_vector_db_key)
 
@@ -57,8 +57,10 @@ class DalTests(unittest.TestCase):
 
         all_users = dal.get_all_users()
         self.assertEquals(3, len(all_users))
-        for email in users_email:
-            self.assertTrue(next(user for user in all_users if user.email == email), None)  # check email is in list
+
+        result_user_emails = sorted([user.email for user in all_users])
+        for (expected, result) in zip(users_email, result_user_emails):
+            self.assertEquals(expected, result)
 
     def test_save_then_get_user_docs_should_be_equals(self):
         # setup : init docs in database
@@ -71,7 +73,9 @@ class DalTests(unittest.TestCase):
         doc2 = struct.Document.make_from_db(
             url=db_doc2.url, title=db_doc2.title, summary=None, date=None, db_key=db_doc2.key)
 
-        expected_user_docs = [struct.UserDocument(doc1, 0.1), struct.UserDocument(doc2, 0.2)]
+        expected_user_docs = [
+            struct.UserDocument.make_from_scratch(doc1, 0.1),
+            struct.UserDocument.make_from_scratch(doc2, 0.2)]
 
         # create user and save it to init user_document_set_key field
         user = struct.User.make_from_scratch("test_save_then_get_user_docs_should_be_equals")
@@ -92,6 +96,7 @@ class DalTests(unittest.TestCase):
             url='url2_test_save_documents', title='title1_test_save_documents', summary='summary2')
         expected_docs = [expected_doc1, expected_doc2]
         dal.save_documents(expected_docs)
+
         for expected_doc in expected_docs:
             result_doc = expected_doc.db_key.get()
             self.assertEquals(expected_doc.url, result_doc.url)
@@ -103,7 +108,7 @@ class DalTests(unittest.TestCase):
         feature1 = db.FeatureDescription.make('desc1')
         feature_set = db.FeatureSet.make(feature_set_id='set', feature_descriptions=[feature1, feature2])
         feature_set.put()
-        expected_feat_vec = struct.FeatureVector(
+        expected_feat_vec = struct.FeatureVector.make_from_scratch(
             vector=[0.5, 0.6], labels=['desc1', 'desc2'], feature_set_id=feature_set.key.id())
 
         user = struct.User.make_from_scratch('test_save_then_get_user_feature_vector_should_be_equals')

--- a/src/server/tests/test_dal.py
+++ b/src/server/tests/test_dal.py
@@ -37,18 +37,18 @@ class DalTests(unittest.TestCase):
         expected_user = struct.User.make_from_scratch(email=user_email)
 
         # ------------- check save_user --------------
-        self.assertIsNone(expected_user.feature_vector_db_key)
-        self.assertIsNone(expected_user.user_doc_set_db_key)
+        self.assertIsNone(expected_user._feature_vector_db_key)
+        self.assertIsNone(expected_user._user_doc_set_db_key)
         dal.save_user(expected_user)
         # save should init db keys
-        self.assertIsNotNone(expected_user.user_doc_set_db_key)
-        self.assertIsNotNone(expected_user.feature_vector_db_key)
+        self.assertIsNotNone(expected_user._user_doc_set_db_key)
+        self.assertIsNotNone(expected_user._feature_vector_db_key)
 
         # ------------- check get_user --------------
         result_user = dal.get_user('email')
         self.assertEquals(expected_user.email, result_user.email)
-        self.assertEquals(expected_user.user_doc_set_db_key, result_user.user_doc_set_db_key)
-        self.assertEquals(expected_user.feature_vector_db_key, result_user.feature_vector_db_key)
+        self.assertEquals(expected_user._user_doc_set_db_key, result_user._user_doc_set_db_key)
+        self.assertEquals(expected_user._feature_vector_db_key, result_user._feature_vector_db_key)
 
     def test_get_all_users(self):
         users_email = ['user1', 'user2', 'user3']
@@ -98,7 +98,7 @@ class DalTests(unittest.TestCase):
         dal.save_documents(expected_docs)
 
         for expected_doc in expected_docs:
-            result_doc = expected_doc.db_key.get()
+            result_doc = expected_doc._db_key.get()
             self.assertEquals(expected_doc.url, result_doc.url)
             self.assertEquals(expected_doc.title, result_doc.title)
             self.assertEquals(expected_doc.summary, result_doc.summary)

--- a/src/server/tests/test_dal.py
+++ b/src/server/tests/test_dal.py
@@ -5,6 +5,7 @@ from google.appengine.ext import ndb
 from google.appengine.ext import testbed
 import server.dal as dal
 import server.dbentities as db
+import server.frontendstructs as struct
 
 
 class DalTests(unittest.TestCase):
@@ -32,39 +33,90 @@ class DalTests(unittest.TestCase):
 
     def test_save_then_get_user_should_be_equals(self):
         # ------ init database -----------
+        user_email = 'email'
+        expected_user = struct.User.make_from_scratch(email=user_email)
+
+        # ------------- check save_user --------------
+        self.assertIsNone(expected_user.feature_vector_db_key)
+        self.assertIsNone(expected_user.user_doc_set_db_key)
+        dal.save_user(expected_user)
+        #save should init db keys
+        self.assertIsNotNone(expected_user.user_doc_set_db_key)
+        self.assertIsNotNone(expected_user.feature_vector_db_key)
+
+        # ------------- check get_user --------------
+        result_user = dal.get_user('email')
+        self.assertEquals(expected_user.email, result_user.email)
+        self.assertEquals(expected_user.user_doc_set_db_key, result_user.user_doc_set_db_key)
+        self.assertEquals(expected_user.feature_vector_db_key, result_user.feature_vector_db_key)
+
+    def test_get_all_users(self):
+        users_email = ['user1', 'user2', 'user3']
+        for email in users_email:
+            dal.save_user(struct.User.make_from_scratch(email=email))
+
+        all_users = dal.get_all_users()
+        self.assertEquals(3, len(all_users))
+        for email in users_email:
+            self.assertTrue(next(user for user in all_users if user.email == email), None)  # check email is in list
+
+    def test_save_then_get_user_docs_should_be_equals(self):
+        # setup : init docs in database
         db_doc1 = db.Document.make(url='url1', title='title1', summary=None)
         db_doc2 = db.Document.make(url='url2', title='title2', summary=None)
+        ndb.put_multi([db_doc1, db_doc2])
 
-        feature1 = db.FeatureDescription.make('desc1')
-        feature2 = db.FeatureDescription.make('desc2')
-        feature_set = db.FeatureSet.make(feature_set_id='set', feature_descriptions=[feature1, feature2])
-        ndb.put_multi([db_doc1, db_doc2, feature_set])  # we must store entities before creating user to init key fields
+        doc1 = struct.Document.make_from_db(
+            url=db_doc1.url, title=db_doc1.title, summary=None, date=None, db_key=db_doc1.key)
+        doc2 = struct.Document.make_from_db(
+            url=db_doc2.url, title=db_doc2.title, summary=None, date=None, db_key=db_doc2.key)
 
-        doc1 = dal.Document(url=db_doc1.url, title=db_doc1.title, db_key=db_doc1.key)
-        doc2 = dal.Document(url=db_doc2.url, title=db_doc2.title, db_key=db_doc2.key)
+        expected_user_docs = [struct.UserDocument(doc1, 0.1), struct.UserDocument(doc2, 0.2)]
 
-        feature_vector = dal.FeatureVector(vector=[0.5, 0.6], labels=['desc1', 'desc2'], feature_set_id=feature_set.key.id())
+        # create user and save it to init user_document_set_key field
+        user = struct.User.make_from_scratch("test_save_then_get_user_docs_should_be_equals")
+        dal.save_user(user)
 
-        user_docs = [dal.UserDocument(doc1, 0.1), dal.UserDocument(doc2, 0.2)]
-        expected_user = dal.User(email='email', user_docs=user_docs, feature_vector=feature_vector)
+        dal.save_user_docs(user, expected_user_docs)
+        result_user_docs = dal.get_user_docs(user)
+        self.assertEquals(len(expected_user_docs), len(result_user_docs))
 
-        # ------------- Save then get user --------------
-        dal.save_user(expected_user)
-        result_user = dal.get_user('email')
-
-        # --------------assert equality ------------------
-        self.assertEquals(expected_user.email, result_user.email)
-
-        expected_feat_vec = expected_user.feature_vector
-        result_feat_vec = result_user.feature_vector
-        self.assertEquals(expected_feat_vec.feature_set_id, result_feat_vec.feature_set_id)
-        self.assertEquals(expected_feat_vec.vector, result_feat_vec.vector)
-        self.assertEquals(expected_feat_vec.labels, result_feat_vec.labels)
-
-        for (expected, result) in itertools.izip_longest(expected_user.user_docs, result_user.user_docs):
+        for (expected, result) in itertools.izip_longest(expected_user_docs, result_user_docs):
             self.assertEquals(expected.grade, result.grade)
             self.assertEquals(expected.document.title, result.document.title)
 
+    def test_save_documents(self):
+        expected_doc1 = struct.Document.make_from_scratch(
+            url='url1_test_save_documents', title='title1_test_save_documents', summary='summary1')
+        expected_doc2 = struct.Document.make_from_scratch(
+            url='url2_test_save_documents', title='title1_test_save_documents', summary='summary2')
+        expected_docs = [expected_doc1, expected_doc2]
+        dal.save_documents(expected_docs)
+        for expected_doc in expected_docs:
+            result_doc = expected_doc.db_key.get()
+            self.assertEquals(expected_doc.url, result_doc.url)
+            self.assertEquals(expected_doc.title, result_doc.title)
+            self.assertEquals(expected_doc.summary, result_doc.summary)
+
+    def test_save_then_get_user_feature_vector_should_be_equals(self):
+        feature2 = db.FeatureDescription.make('desc2')
+        feature1 = db.FeatureDescription.make('desc1')
+        feature_set = db.FeatureSet.make(feature_set_id='set', feature_descriptions=[feature1, feature2])
+        feature_set.put()
+        expected_feat_vec = struct.FeatureVector(
+            vector=[0.5, 0.6], labels=['desc1', 'desc2'], feature_set_id=feature_set.key.id())
+
+        user = struct.User.make_from_scratch('test_save_then_get_user_feature_vector_should_be_equals')
+        dal.save_user(user)
+        dal.save_user_feature_vector(user, expected_feat_vec)
+
+        result_feat_vec = dal.get_user_feature_vector(
+            dal.get_user('test_save_then_get_user_feature_vector_should_be_equals')
+        )
+
+        self.assertEquals(expected_feat_vec.feature_set_id, result_feat_vec.feature_set_id)
+        self.assertEquals(expected_feat_vec.vector, result_feat_vec.vector)
+        self.assertEquals(expected_feat_vec.labels, result_feat_vec.labels)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/server/tests/test_dal.py
+++ b/src/server/tests/test_dal.py
@@ -134,7 +134,8 @@ class DalTests(unittest.TestCase):
         self.assertEqual(0.1, result_vectors[0].vector[0])
         self.assertEqual(0.2, result_vectors[1].vector[0])
 
-    def build_dummy_feature_set(self):
+    @staticmethod
+    def build_dummy_feature_set():
         feature2 = db.FeatureDescription.make('desc2')
         feature1 = db.FeatureDescription.make('desc1')
         feature_set = db.FeatureSet.make(feature_set_id='set', feature_descriptions=[feature1, feature2])


### PR DESCRIPTION
We want to be able to edit the "user" entity form server
In the same time the learning process will edit user_documents and feature-vector.
In datastore, a write always write the whole entity, so we change this entites
from "ndb.StructuredProperty" to "ndb.KeyProperty" to edit the content of this
entities without affecting the keys owned by the user entity