### PR TITLE
[TopicModeller] increase perf by caching call to stopwords.words('eng…

### DIFF
--- a/src/orchestrator/orchestrator/initialize_topicmodeller.py
+++ b/src/orchestrator/orchestrator/initialize_topicmodeller.py
@@ -14,6 +14,12 @@ def initialize_topicmodeller(topic_modeller, html_documents, tm_data_folder, num
     topic_modeller.save(tm_data_folder)
 
 
+def initialize_with_existing_dict(topic_modeller, html_documents, tm_data_folder, num_topics):
+    topic_modeller.load_dictionary(tm_data_folder)
+    topic_modeller.initialize_model(html_documents, num_topics)
+    topic_modeller.save_model(tm_data_folder)
+
+
 def initialize_db(topic_modeller):
     feature_names = [words[0] for (_, words) in topic_modeller.topics]
     dal.save_features(dal.REF_FEATURE_SET, feature_names)

--- a/src/topicmodeller/tests/test_topicmodeller.py
+++ b/src/topicmodeller/tests/test_topicmodeller.py
@@ -21,6 +21,7 @@ class TopicModellerTests(unittest.TestCase):
         docs = [doc1, doc2]
 
         topic_modeller = TopicModeller(self.MockTokenizer())
+        topic_modeller._remove_optimizations = True  # pylint: disable=protected-access
         topic_modeller.initialize(docs, num_topics=2)
 
         # check number of topics is expected

--- a/src/topicmodeller/topicmodeller/doctokenizer.py
+++ b/src/topicmodeller/topicmodeller/doctokenizer.py
@@ -23,7 +23,8 @@ def _clean(words):
 
 
 def _remove_stop_words(words):
-    return [word for word in words if word not in stopwords.words('english')]
+    english_words = stopwords.words('english')  # don't inline call in for loop: (long complex call)
+    return [word for word in words if word not in english_words]
 
 
 def _filter_latin_words(words):

--- a/src/topicmodeller/topicmodeller/doctokenizer.py
+++ b/src/topicmodeller/topicmodeller/doctokenizer.py
@@ -23,7 +23,7 @@ def _clean(words):
 
 
 def _remove_stop_words(words):
-    english_words = stopwords.words('english')  # don't inline call in for loop: (long complex call)
+    english_words = set(stopwords.words('english'))  # don't inline call in for loop: (long complex call)
     return [word for word in words if word not in english_words]
 
 

--- a/src/topicmodeller/topicmodeller/topicmodeller.py
+++ b/src/topicmodeller/topicmodeller/topicmodeller.py
@@ -21,6 +21,7 @@ class TopicModeller(object):
         self._lda = None
         self.topics = None
         self._tokenizer = document_tokenizer
+        self._remove_optimizations = False  # can be set to 'True' for testing purpose
         np.random.seed(2406834896)  # to get reproductible results
         # nb: ideally gensim should allow to inject RandomState to not make side effects on other libs using numpy RNG
 
@@ -108,7 +109,8 @@ class TopicModeller(object):
         self._dictionary = corpora.Dictionary()
         corpora.Dictionary.add_documents(self._dictionary, tokenized_documents)
         # memory is O(size(_dictionary) * nb_topics), filter_extremes removes irrelevant words (too rare or too frequent)
-        self._dictionary.filter_extremes()
+        if not self._remove_optimizations:
+            self._dictionary.filter_extremes()
 
     def _feed(self, documents, num_topics):
         corpus = []


### PR DESCRIPTION
…lish')

The method stopwords.words('english') was called for each word of each document, and once for filling dico, once for modelling. It was taking 70% of the time of topicModeller !
This change divides by 3 the running time in profiling (200s=>70s for 1000 docs 128 topics)