### PR TITLE
Split doctokenizer

### DIFF
--- a/src/orchestrator/launch_initialize_topicmodeller.py
+++ b/src/orchestrator/launch_initialize_topicmodeller.py
@@ -27,13 +27,13 @@ def run_init_tm_and_db(documents_folder, tm_data_folder, num_topics):
 
     html_documents = RepeatableHtmlDocuments(documents_folder)
 
-    initialize_topicmodeller_and_db(TopicModeller.make(), html_documents, tm_data_folder, num_topics)
+    initialize_topicmodeller_and_db(TopicModeller.make_with_html_tokenizer(), html_documents, tm_data_folder, num_topics)
 
 
 def run_init_db(tm_data_folder):
     initialize_remote_api()
 
-    topic_modeller = TopicModeller.make()
+    topic_modeller = TopicModeller.make_with_html_tokenizer()
     topic_modeller.load(tm_data_folder)
     initialize_db(topic_modeller)
 

--- a/src/orchestrator/launch_scrap_and_learn.py
+++ b/src/orchestrator/launch_scrap_and_learn.py
@@ -35,7 +35,7 @@ def launch_scrap_and_learn(scraper, doc_saver, tm_data_folder, hashed_urls_file)
     user_docs_max_size = 30
     docs_chunk_size = 1000
 
-    topic_modeller = TopicModeller.make()
+    topic_modeller = TopicModeller.make_with_html_tokenizer()
     topic_modeller.load(tm_data_folder)
 
     url_unicity_checker = UrlUnicityChecker(hashed_urls_file)

--- a/src/topicmodeller/tests/test_doctokenizer.py
+++ b/src/topicmodeller/tests/test_doctokenizer.py
@@ -5,7 +5,7 @@ import os
 import unittest
 import jsonpickle
 from topicmodeller.doctokenizer import _filter_latin_words, _readable_document, _remove_stop_words, _word_tokenize, \
-    DocTokenizer
+    DocTokenizerFromHtml, DocTokenizerFromRawText
 
 
 class DocTokenizerTests(unittest.TestCase):
@@ -51,16 +51,28 @@ class DocTokenizerTests(unittest.TestCase):
 
         self.assertTrue(not _filter_latin_words([u'1000']))
 
-    def test_tokenize(self):
+    def test_tokenize_from_html(self):
         directory = os.path.dirname(os.path.abspath(__file__))
         file_content = open(os.path.join(directory, 'scraper_documents/2015-08-01 18:00:22.926317_8.json')).read()
         html_content = jsonpickle.decode(file_content).html_content
-        tokenizer = DocTokenizer()
+        tokenizer = DocTokenizerFromHtml()
         tokenized = tokenizer.tokenize(html_content)
 
         self.assertTrue(len(tokenized) > 200)
         self.assertTrue('a' not in tokenized)  # no too common english words
         self.assertTrue('as' not in tokenized)
+        self.assertTrue(word.lower() == word for word in tokenized)  # lower cases
+
+    def test_tokenize_from_rawtext(self):
+        tokenizer = DocTokenizerFromRawText()
+        tokenized = tokenizer.tokenize('This is raw text tokenizer')
+
+        # no too common english words
+        self.assertTrue('this' not in tokenized)
+        self.assertTrue('is' not in tokenized)
+        self.assertTrue('raw' in tokenized)
+        self.assertTrue('text' in tokenized)
+        self.assertTrue('tokenizer' in tokenized)
         self.assertTrue(word.lower() == word for word in tokenized)  # lower cases
 
 

--- a/src/topicmodeller/topicmodeller/doctokenizer.py
+++ b/src/topicmodeller/topicmodeller/doctokenizer.py
@@ -31,11 +31,18 @@ def _filter_latin_words(words):
     return [word for word in words if re.search(r'^[a-zA-Z]*$', word) is not None]
 
 
-class DocTokenizer(object):
+class DocTokenizerFromHtml(object):
 
     @classmethod
     def tokenize(cls, html_document):
-        word_tokenized_document = _word_tokenize(_readable_document(html_document))
+        return DocTokenizerFromRawText.tokenize(_readable_document(html_document))
+
+
+class DocTokenizerFromRawText(object):
+
+    @classmethod
+    def tokenize(cls, raw_text):
+        word_tokenized_document = _word_tokenize(raw_text)
         lowercase_document = [word.lower() for word in word_tokenized_document]
         document = _clean(lowercase_document)
         return document

--- a/src/topicmodeller/topicmodeller/topicmodeller.py
+++ b/src/topicmodeller/topicmodeller/topicmodeller.py
@@ -4,15 +4,19 @@
 import os
 import numpy as np
 from gensim import corpora, models
-from .doctokenizer import DocTokenizer
+from .doctokenizer import DocTokenizerFromRawText, DocTokenizerFromHtml
 
 
 class TopicModeller(object):
     corpus_batch_size = 250
 
     @classmethod
-    def make(cls):
-        return TopicModeller(DocTokenizer())
+    def make_with_html_tokenizer(cls):
+        return TopicModeller(DocTokenizerFromHtml())
+
+    @classmethod
+    def make_with_rawtext_tokenizer(cls):
+        return TopicModeller(DocTokenizerFromRawText())
 
     # constructor allowing injection of custom tokenizer
     def __init__(self, document_tokenizer):


### PR DESCRIPTION
Split doctokenizer to be able to tokenize,
- html documents
- raw text documents
We will need to tokenize raw text document, to tokenize user interests